### PR TITLE
Rewrote logic so it doesn't short circuit

### DIFF
--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -19,9 +19,6 @@ class Slack extends Service {
         case 'outage':
           this.status = Status.MAJOR
           break
-        case 'notice':
-          this.status = Status.MAINTENANCE
-          break
         default:
           this.status = Status.OPERATIONAL
       }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -11,24 +11,20 @@ class Slack extends Service {
   async updateStatus(settings: SettingsState) {
     const summary = await axios.get(`${this.domain}/api/v2.0.0/current`)
 
-    if (summary.data.status === 'ok') {
+    if (summary.data.status === 'active') {
+      switch (summary.data.type) {
+        case 'incident':
+          this.status = Status.MINOR
+          break
+        case 'outage':
+          this.status = Status.MAJOR
+          break
+        case 'notice':
+          this.status = Status.MAINTENANCE
+          break
+      }
+    } else {
       this.status = Status.OPERATIONAL
-
-      return
-    }
-
-    switch (summary.data.type) {
-      case 'incident':
-        this.status = Status.MINOR
-        break
-      case 'outage':
-        this.status = Status.MAJOR
-        break
-      case 'notice':
-        this.status = Status.MAINTENANCE
-        break
-      default:
-        this.status = Status.OPERATIONAL
     }
 
     this.triggerNotification(settings)

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -22,6 +22,8 @@ class Slack extends Service {
         case 'notice':
           this.status = Status.MAINTENANCE
           break
+        default:
+          this.status = Status.OPERATIONAL
       }
     } else {
       this.status = Status.OPERATIONAL


### PR DESCRIPTION
Previous status and notification triggers were ignored meaning if the service comes back online the user wouldn't be notified