### PR TITLE
Add Hund-based services & Bitwarden

### DIFF
--- a/src/services/base/hund.ts
+++ b/src/services/base/hund.ts
@@ -1,0 +1,63 @@
+import { SettingsState } from '../../types'
+import Service from '../service'
+import Status from '../status'
+
+// --
+
+async function getFirstEventInSSEStream<T>(url: string) {
+  return new Promise<T>((resolve, reject) => {
+    const eventSource = new EventSource(url)
+    eventSource.addEventListener('init_event', (event: any) => {
+      try {
+        resolve(JSON.parse(event.data))
+      } catch (error) {
+        reject(error)
+      } finally {
+        eventSource.close()
+      }
+    })
+    eventSource.onerror = (error) => {
+      eventSource.close()
+      reject(error)
+    }
+  })
+}
+
+// https://hund.io/help/documentation/live-event-streams
+interface HundStatus {
+  state: 'operational' | 'degraded' | 'outage'
+}
+
+class HundService extends Service {
+  constructor(name: string, domain: string) {
+    super(name, domain)
+  }
+
+  async updateStatus(settings: SettingsState) {
+    const status = await getFirstEventInSSEStream<HundStatus>(
+      `${this.domain}/live/v2/status_page`
+    )
+    switch (status.state) {
+      case 'operational':
+        this.status = Status.OPERATIONAL
+        break
+      case 'degraded':
+        // Only some components are having an outage
+        this.status = Status.PARTIAL
+        break
+      case 'outage':
+        // Top-level status is set to 'outage' when all the sub-components are
+        // on 'outage' themselves, so considered a major outage
+        this.status = Status.MAJOR
+        break
+      default:
+        this.status = Status.OPERATIONAL
+        break
+    }
+
+    this.triggerNotification(settings)
+    this.prevStatus = this.status
+  }
+}
+
+export default HundService

--- a/src/services/hund/bitwarden.ts
+++ b/src/services/hund/bitwarden.ts
@@ -1,0 +1,11 @@
+import HundService from '../base/hund'
+
+class Bitwarden extends HundService {
+  constructor() {
+    const name = 'Bitwarden'
+    const url = 'https://status.bitwarden.com'
+    super(name, url)
+  }
+}
+
+export default Bitwarden

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -138,6 +138,9 @@ import Wasabi from './statusio/wasabi'
 // Cachet services
 import CleverCloud from './cachet/clevercloud'
 
+// Hund services
+import Bitwarden from './hund/bitwarden'
+
 // Custom services
 import Algolia from './algolia'
 import Stripe from './stripe'
@@ -284,6 +287,9 @@ const allServices = new Map<string, Service>([
 
   // Cachet pages
   ['Clever Cloud', new CleverCloud()],
+
+  // Hund pages
+  ['Bitwarden', new Bitwarden()],
 
   // Custom pages
   ['Algolia', new Algolia()],


### PR DESCRIPTION
Closes #28.

The event stream is opened every 5 seconds (or whatever the polling timeout is set to), and only the `init_event` message is read and parsed before closing the connection.

Best of both worlds, and no need to hack around with Axios 🙂

I did not have to polyfill `EventSource`, so I guess the service code runs in the browser side, not the Node.js side ? That would be consistent with my debugging experience.