### PR TITLE
Add OhMySMTP (transactional emails)

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -153,6 +153,7 @@ import Heroku from './heroku'
 import AWS from './aws'
 import Postmark from './postmark'
 import Slack from './slack'
+import OhMySMTP from './ohmysmtp'
 
 const allServices = new Map<string, Service>([
   // Instatus pages
@@ -237,6 +238,7 @@ const allServices = new Map<string, Service>([
   ['Newrelic', new Newrelic()],
   ['Notion', new Notion()],
   ['Npm', new Npm()],
+  ['OhMySMTP', new OhMySMTP()],
   ['OnePassword', new OnePassword()],
   ['Packet', new Packet()],
   ['PagerDuty', new PagerDuty()],

--- a/src/services/ohmysmtp.ts
+++ b/src/services/ohmysmtp.ts
@@ -1,0 +1,44 @@
+import axios from 'axios'
+import { SettingsState } from '../types'
+import Service from './service'
+import Status from './status'
+
+class OhMySMTP extends Service {
+  constructor() {
+    super('OhMySMTP', 'https://status.ohmysmtp.com/')
+    this.status = Status.OPERATIONAL
+  }
+
+  async updateStatus(settings: SettingsState) {
+    const summary = await axios.get(
+      'https://raw.githubusercontent.com/ohmysmtp/status/master/history/summary.json'
+    )
+    const statuses: string[] = summary.data.map((component) => component.status)
+    const upStatuses = statuses.filter((status) => status === 'up')
+
+    if (statuses.length === upStatuses.length) {
+      this.status = Status.OPERATIONAL
+    } else if (upStatuses.length === 0) {
+      this.status = Status.MAJOR
+    } else {
+      // Case-by-case
+      const appStatus = summary.data.find(
+        (comp) => comp.slug === 'application'
+      )?.status
+      const smtpServerStatus = summary.data.find(
+        (comp) => comp.slug === 'smtp-server'
+      )?.status
+      if (appStatus !== 'ok' || smtpServerStatus !== 'ok') {
+        this.status = Status.PARTIAL
+      } else {
+        // Some non-critical components are down (eg: docs, landing page)
+        this.status = Status.MINOR
+      }
+    }
+
+    this.triggerNotification(settings)
+    this.prevStatus = this.status
+  }
+}
+
+export default OhMySMTP


### PR DESCRIPTION
Status page: https://status.ohmysmtp.com/

Note: their status page is provided by https://upptime.js.org, which does not provide a built-in way to resolve the JSON summary file hosted on GitHub from the status page domain, so unfortunately Upptime cannot be factored into a service like other status page providers.